### PR TITLE
Fix schema name and Guid creation

### DIFF
--- a/backend/TreeOfAKind.Domain/UserProfiles/UserProfile.cs
+++ b/backend/TreeOfAKind.Domain/UserProfiles/UserProfile.cs
@@ -30,7 +30,7 @@ namespace TreeOfAKind.Domain.UserProfiles
 
         private UserProfile(string authUserId, string? firstName, string? lastName,DateTime? birthDate)
         {
-            Id = new UserId(new Guid());
+            Id = new UserId(Guid.NewGuid());
             AuthUserId = authUserId;
             FirstName = firstName;
             LastName = lastName;

--- a/backend/TreeOfAKind.Infrastructure/Domain/UserProfiles/UserProfileTypeConfiguration.cs
+++ b/backend/TreeOfAKind.Infrastructure/Domain/UserProfiles/UserProfileTypeConfiguration.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using TreeOfAKind.Application.Configuration;
 using TreeOfAKind.Domain.UserProfiles;
+using TreeOfAKind.Infrastructure.Database;
 
 namespace TreeOfAKind.Infrastructure.Domain.UserProfiles
 {
@@ -10,7 +11,7 @@ namespace TreeOfAKind.Infrastructure.Domain.UserProfiles
     {
         public void Configure(EntityTypeBuilder<UserProfile> builder)
         {
-            builder.ToTable("UserProfiles");
+            builder.ToTable("UserProfiles", SchemaNames.Trees);
 
             builder.HasKey(u => u.Id);
 

--- a/backend/TreeOfAKind.Infrastructure/Migrations/20201128152431_MoveUserProfilesToTreesSchema.Designer.cs
+++ b/backend/TreeOfAKind.Infrastructure/Migrations/20201128152431_MoveUserProfilesToTreesSchema.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TreeOfAKind.Infrastructure.Database;
 
 namespace TreeOfAKind.Infrastructure.Migrations
 {
     [DbContext(typeof(TreesContext))]
-    partial class TreesContextModelSnapshot : ModelSnapshot
+    [Migration("20201128152431_MoveUserProfilesToTreesSchema")]
+    partial class MoveUserProfilesToTreesSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/TreeOfAKind.Infrastructure/Migrations/20201128152431_MoveUserProfilesToTreesSchema.cs
+++ b/backend/TreeOfAKind.Infrastructure/Migrations/20201128152431_MoveUserProfilesToTreesSchema.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TreeOfAKind.Infrastructure.Migrations
+{
+    public partial class MoveUserProfilesToTreesSchema : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameTable(
+                name: "UserProfiles",
+                newName: "UserProfiles",
+                newSchema: "trees");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "BirthDate",
+                schema: "trees",
+                table: "UserProfiles",
+                type: "date",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameTable(
+                name: "UserProfiles",
+                schema: "trees",
+                newName: "UserProfiles");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "BirthDate",
+                table: "UserProfiles",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "date",
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Change schema name from default `dbo` to `trees` for UserProfile
May change default schema name in the future. Further investigation needed.