### PR TITLE
Fix version conflicts caused by PR#269

### DIFF
--- a/backend/TreeOfAKind.Infrastructure/TreeOfAKind.Infrastructure.csproj
+++ b/backend/TreeOfAKind.Infrastructure/TreeOfAKind.Infrastructure.csproj
@@ -24,10 +24,10 @@
     <PackageReference Include="Dapper" Version="2.0.78" />
     <PackageReference Include="FirebaseAdmin" Version="2.0.0" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="5.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.1" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.EntityFrameworkCore.Design from 5.0.2 to 5.0.8 in /backend. [(PR#269)](https://github.com/TreeOfAKind/TreeOfAKind/pull/269).
Hope this fix can help you.

Best regards,
sucrose